### PR TITLE
Fixed support for AMD/RequireJS & module.exports

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,8 @@
 	"authors": [
 		"Nedim Arabacı"
 	],
-	"description": "Slack like emoji selector with apple, twitter, google, emojione and custom emoji support."
+	"description": "Slack like emoji selector with apple, twitter, google, emojione and custom emoji support.",
+	"dependencies": {
+		"js-emoji": "^3.1.1"
+	}
 }

--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -9,13 +9,13 @@
 ;
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(factory);
+    define(['js-emoji'], factory);
   } else if (typeof exports === 'object') {
-    module.exports = factory();
+    module.exports = factory(require('js-emoji'));
   } else {
-    root.wdtEmojiBundle = factory();
+    root.wdtEmojiBundle = factory(root.EmojiConvertor);
   }
-})(this, function () {
+})(this, function (EmojiConvertor) {
   var wdtEmojiBundle = {};
 
   wdtEmojiBundle.defaults = {


### PR DESCRIPTION
This way it still works manually, but also modular through AMD or node.

Would prevent things like https://github.com/needim/wdt-emoji-bundle/issues/10 when used modular.