### PR TITLE
Right module EMOJI-JS

### DIFF
--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -9,9 +9,9 @@
 ;
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['js-emoji'], factory);
+    define(['emoji-js'], factory);
   } else if (typeof exports === 'object') {
-    module.exports = factory(require('js-emoji'));
+    module.exports = factory(require('emoji-js'));
   } else {
     root.wdtEmojiBundle = factory(root.EmojiConvertor);
   }


### PR DESCRIPTION
Just to put the name of the right module. js-emoji --> emoji-js.
Annoying problem when you work with a team that has to manually change that.