### PR TITLE
Restore selection in contentEditable

### DIFF
--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -659,7 +659,7 @@
       }
     });
 
-    addListenerMulti(el, 'mouseup keyup input', function () {
+    addListenerMulti(el, 'focus mouseup keyup input', function () {
       wdtEmojiBundle.ranges[this.dataset.rangeIndex] = window.getSelection().getRangeAt(0);
     });
 

--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -659,7 +659,7 @@
       }
     });
 
-    addListenerMulti(el, 'mouseup keyup', function () {
+    addListenerMulti(el, 'mouseup keyup input', function () {
       wdtEmojiBundle.ranges[this.dataset.rangeIndex] = window.getSelection().getRangeAt(0);
     });
 


### PR DESCRIPTION
`execCommand` in `replaceText` wont trigger mouseup or keyup and that's why we lose caret

Closes #39